### PR TITLE
fix: update from igor to igor2

### DIFF
--- a/SciFiReaders/readers/microscopy/spm/afm/igor_ibw.py
+++ b/SciFiReaders/readers/microscopy/spm/afm/igor_ibw.py
@@ -15,11 +15,11 @@ import re
 from warnings import warn
 
 try:
-    from igor import binarywave as bw
+    from igor2 import binarywave as bw
 except ModuleNotFoundError:
-    print("You don't have igor installed. \
+    print("You don't have igor2 installed. \
     If you wish to open igor files, you will need to install it \
-    (pip install igor) before attempting.")
+    (pip install igor2) before attempting.")
     bw = None
 
 class IgorMatrixReader(Reader):
@@ -30,8 +30,8 @@ class IgorMatrixReader(Reader):
     """
     def __init__(self, file_path, *args, **kwargs):
         if bw == None:
-            raise ModuleNotFoundError('You attempted to load an Igor file, but this requires igor.\n \
-            Please Load it with pip install igor , restart and retry')
+            raise ModuleNotFoundError('You attempted to load an Igor file, but this requires igor2.\n \
+            Please Load it with pip install igor2 , restart and retry')
 
         super().__init__(file_path, *args, **kwargs)
 
@@ -261,8 +261,8 @@ class IgorIBWReader(Reader):
     """
     def __init__(self, file_path, *args, **kwargs):
         if bw == None:
-            raise ModuleNotFoundError('You attempted to load an Igor file, but this requires igor.\n \
-            Please Load it with pip install igor , restart and retry')
+            raise ModuleNotFoundError('You attempted to load an Igor file, but this requires igor2.\n \
+            Please Load it with pip install igor2 , restart and retry')
 
         super().__init__(file_path, *args, **kwargs)
 

--- a/extras_require.txt
+++ b/extras_require.txt
@@ -1,5 +1,5 @@
 hyperspy
-igor
+igor2
 nanonispy
 pyUSID
 pyNSID

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies
     extras_require={
         'hyperspy':  ["hyperspy"],
-        'igor': ["igor"],
+        'igor2': ["igor2"],
         "gwyddion": ["gwyfile"],
         'nanonispy': ['nanonispy'],
         'sid': ['pyUSID', 'pyNSID'],

--- a/tests/readers/microscopy/spm/afm/test_igor.py
+++ b/tests/readers/microscopy/spm/afm/test_igor.py
@@ -12,7 +12,7 @@ import SciFiReaders as sr
 
 root_path = "https://github.com/pycroscopy/SciFiDatasets/blob/main/data/microscopy/spm/afm/"
 
-igor = pytest.importorskip("igor", reason="igor not installed")
+igor2 = pytest.importorskip("igor2", reason="igor2 not installed")
 
 class TestIgorIBW(unittest.TestCase):
     # Tests the nanonis_dat reader


### PR DESCRIPTION
igor no longer works with numpy as of numpy 1.20. If trying to import SciFiReaders with igor, we get the following error:

"AttributeError: module 'numpy' has no attribute 'complex'."

indicating the issue. Because of this deprecation issue, AFM-Analysis have forked the original wking/igor, and updated it into a new repository called igor2.

This CL updates SciFiReaders to use igor2 instead of igor. The igor unit tests have been tested and pass. The changes here correspond exclusively to changing text from 'igor' to 'igor2' for package purposes and user prompts (we do not change any class/variable names).

Note: for 2 files, the diff will show the addition of a \newline at the end of the file. This is unix policy and done by default by my editor.

resolves #96 