### PR TITLE
EMD reader recognizes reciprocal dimensions

### DIFF
--- a/SciFiReaders/readers/microscopy/em/tem/emd_reader.py
+++ b/SciFiReaders/readers/microscopy/em/tem/emd_reader.py
@@ -251,7 +251,6 @@ class EMDReader(sidpy.Reader):
                                                                dimension_type='spatial'))
             
             # for diffraction patterns
-            # if you have an image stack of diffraction patterns, may not work?
             if '1/' in self.metadata['BinaryResult']['PixelUnitX']:
                 self.datasets[-1].set_dimension(0, sidpy.Dimension(np.arange(self.data_array.shape[0]) * (scale_x / 1e18),
                                                                    name='u', units='1/nm',

--- a/SciFiReaders/readers/microscopy/em/tem/emd_reader.py
+++ b/SciFiReaders/readers/microscopy/em/tem/emd_reader.py
@@ -249,6 +249,19 @@ class EMDReader(sidpy.Reader):
                                                                name='y', units='nm',
                                                                quantity='distance',
                                                                dimension_type='spatial'))
+            
+            # for diffraction patterns
+            # if you have an image stack of diffraction patterns, may not work?
+            if '1/' in self.metadata['BinaryResult']['PixelUnitX']:
+                self.datasets[-1].set_dimension(0, sidpy.Dimension(np.arange(self.data_array.shape[0]) / scale_x,
+                                                                   name='u', units='1/nm',
+                                                                   quantity='reciprocal distance',
+                                                                   dimension_type='reciprocal'))
+                self.datasets[-1].set_dimension(1, sidpy.Dimension(np.arange(self.data_array.shape[1]) / scale_y,
+                                                                   name='v', units='1/nm',
+                                                                   quantity='reciprocal distance',
+                                                                   dimension_type='reciprocal'))
+
         else:
             # There is a problem with random access of data due to chunking in hdf5 files
             # Speed-up copied from hyperspy.ioplugins.EMDReader.FEIEMDReader

--- a/SciFiReaders/readers/microscopy/em/tem/emd_reader.py
+++ b/SciFiReaders/readers/microscopy/em/tem/emd_reader.py
@@ -253,11 +253,11 @@ class EMDReader(sidpy.Reader):
             # for diffraction patterns
             # if you have an image stack of diffraction patterns, may not work?
             if '1/' in self.metadata['BinaryResult']['PixelUnitX']:
-                self.datasets[-1].set_dimension(0, sidpy.Dimension(np.arange(self.data_array.shape[0]) / scale_x,
+                self.datasets[-1].set_dimension(0, sidpy.Dimension(np.arange(self.data_array.shape[0]) * (scale_x / 1e18),
                                                                    name='u', units='1/nm',
                                                                    quantity='reciprocal distance',
                                                                    dimension_type='reciprocal'))
-                self.datasets[-1].set_dimension(1, sidpy.Dimension(np.arange(self.data_array.shape[1]) / scale_y,
+                self.datasets[-1].set_dimension(1, sidpy.Dimension(np.arange(self.data_array.shape[1]) * (scale_y / 1e18),
                                                                    name='v', units='1/nm',
                                                                    quantity='reciprocal distance',
                                                                    dimension_type='reciprocal'))


### PR DESCRIPTION
added a check if '1/' is in units name, then set dimensions accordingly.