### PR TITLE
[fix] incorrect xy units in IgorIBWReader

### DIFF
--- a/SciFiReaders/readers/microscopy/spm/afm/igor_ibw.py
+++ b/SciFiReaders/readers/microscopy/spm/afm/igor_ibw.py
@@ -328,11 +328,11 @@ class IgorIBWReader(Reader):
                 #Add dimension info
                 data_set.set_dimension(0, sid.Dimension(np.linspace(0, parm_dict['FastScanSize'], num_cols),
                                                         name = 'x',
-                                                        units=chan_units[channel], quantity = 'x',
+                                                        units='m', quantity = 'x',
                                                         dimension_type='spatial'))
                 data_set.set_dimension(1, sid.Dimension(np.linspace(0, parm_dict['SlowScanSize'], num_rows),
                                                         name = 'y',
-                                                        units=chan_units[channel], quantity='y',
+                                                        units='m', quantity='y',
                                                         dimension_type='spatial'))
 
                 # append metadata


### PR DESCRIPTION
The existing code was using the z-axis units for the x- and y-axes. However, the x- and y-axes should always be 'm' (as far as I understand), as they correspond to distance units (x and y physical space) for all channels.