### PR TITLE
[fix] correct flip x/y axes reading igor ibw

### DIFF
--- a/SciFiReaders/readers/microscopy/spm/afm/igor_ibw.py
+++ b/SciFiReaders/readers/microscopy/spm/afm/igor_ibw.py
@@ -62,7 +62,7 @@ class IgorMatrixReader(Reader):
 
         data_mat = ibw_obj['wave']['wData']
         if self.parm_dict['datatype']=='image':
-            data_mat = np.rot90(data_mat,3)
+            data_mat = np.flip(data_mat, axis=0)
             xvec = np.linspace(0, self.parm_dict['image_width'], data_mat.shape[1])
             yvec = np.linspace(0, self.parm_dict['image_height'], data_mat.shape[0] )
             

--- a/tests/readers/microscopy/spm/afm/test_igor.py
+++ b/tests/readers/microscopy/spm/afm/test_igor.py
@@ -78,7 +78,7 @@ class TestIgorIBW(unittest.TestCase):
         true_dd = 'I 3 37-1 Backward Down (A)'
         assert dataset.data_descriptor==true_dd, "Data descriptor was expected to be {} \
         but received {}".format(true_dd, dataset.data_descriptor)
-        dimension_sizes = [58,256]
+        dimension_sizes = [256,58]
         dimension_types = [sidpy.DimensionType.SPATIAL, sidpy.DimensionType.SPATIAL]
         for dim in dataset._axes:
             dimension = dataset._axes[dim]


### PR DESCRIPTION
scifireaders does not properly load the scan data. The data is read originally in the same manner as gwyddion, which causes the origin to be misplaced.

In the Asylum UI, the data is displayed as:
  (y)
   ^
   |
   |
   |
   |
   x-------> (x)
(0, 0)

In Gwyddion, the data is displayed as:
(0, 0)
   x-------> (x)
   |
   |
   |
   |
   V
  (y)

In both cases, the actual data is the same! Thus, Gwyddion incorrectly sets the origin and axes.

In an attempt to fix this, the IgorIBWReader performs np.rot90(m, 3), i.e. rotates by 90 \deg 3x counter-clockwise. This *mostly* works, except that it swaps the axes!
We end up with:
  (x)
   ^
   |
   |
   |
   |
   x-------> (y)
(0, 0)

The more 'proper' fix would be to simple perform an np.flip(m, 0) rather than these operations. This is what is done in this CL.

Note also that np.rot90 is used in spm/afm/mdt.py and spm/afm/wxsm.py. I did not include those in this CL because I do not have these instruments and thus could not confirm the same mistake is being made.